### PR TITLE
Various understanding tweaks

### DIFF
--- a/report/src/App.tsx
+++ b/report/src/App.tsx
@@ -238,7 +238,7 @@ const App = () => {
         {targetTotals.map((targetTotal) => {
           const [matching, mismatch, mock, missing] = (targetTotal as string)
             .split("/")
-            .map((i) => parseInt(i as string));
+            .map((i) => parseInt(i as string, 10));
 
           const totalPresent = matching + mismatch + mock;
           const total = totalPresent + missing;
@@ -247,7 +247,7 @@ const App = () => {
           const mismatchPct = pct(mismatch, total);
           const mockPct = pct(mock, total);
 
-          const tooltip = `Missing: ${missing}\nMismatch: ${mismatch}\nMocked: ${mock}\nMatching: ${matching}`;
+          const tooltip = `Matching: ${matching}\nMissing: ${missing}\nMismatch: ${mismatch}\nMocked: ${mock}`;
 
           return (
             <TableCell>
@@ -307,9 +307,10 @@ const App = () => {
           <h3 className="font-semibold text-lg mb-1">Notes</h3>
           <ul className="list-disc list-inside">
             <li className="mb-1">
-              All percentages in the table represent API presence whether the
-              shape of the API matches against the baseline. They are not a
-              calculation of implementation compliance.
+              All percentages in the table represent whether the
+              shape of the API matches against the baseline.
+              <span className="font-bold">They are not a
+              calculation of implementation compliance.</span>
             </li>
             <li className="mb-1">
               The percentages represent the API surface area that is matching,{" "}

--- a/report/src/Legend.tsx
+++ b/report/src/Legend.tsx
@@ -1,23 +1,23 @@
-import { mismatch, stub, supported, unsupported } from "./constants";
+import { mismatch, mock, matching, missing } from "./constants";
 
 export const Legend = () => {
   return (
     <ul className="flex items-center gap-4 border border-slate-300 rounded-md px-4 py-2">
       <li>
-        <span className="mr-1 text-sm font-medium">Supported</span>
-        <span>{supported}</span>
+        <span className="mr-1 text-sm font-medium">Matching</span>
+        <span>{matching}</span>
       </li>
       <li>
-        <span className="mr-1 text-sm font-medium">Unsupported</span>
-        <span>{unsupported}</span>
+        <span className="mr-1 text-sm font-medium">Missing</span>
+        <span>{missing}</span>
       </li>
       <li>
         <span className="mr-1 text-sm font-medium">Mismatch</span>
         <span>{mismatch}</span>
       </li>
       <li>
-        <span className="mr-1 text-sm font-medium">Stub</span>
-        <span>{stub}</span>
+        <span className="mr-1 text-sm font-medium">Mock</span>
+        <span>{mock}</span>
       </li>
     </ul>
   );

--- a/report/src/constants.ts
+++ b/report/src/constants.ts
@@ -1,4 +1,4 @@
-export const supported = "✅";
-export const unsupported = "❌";
-export const stub = "🥸";
+export const matching = "✅";
+export const missing = "❌";
+export const mock = "🥸";
 export const mismatch = "️🩹";

--- a/report/src/utils.ts
+++ b/report/src/utils.ts
@@ -44,7 +44,7 @@ export const pct = (part: number, total: number) => {
   return (part / total) * 100;
 };
 
-export const formatPct = (percentage: number, hideSymbol: boolean = false) => {
+export const formatPct = (percentage: number) => {
   const fractionDigits = percentage === 0 || percentage >= 100 ? 0 : 1;
-  return `${percentage.toFixed(fractionDigits)}${hideSymbol ? "" : "%"}`;
+  return `${percentage.toFixed(fractionDigits)}%`;
 };

--- a/report/src/utils.ts
+++ b/report/src/utils.ts
@@ -44,7 +44,7 @@ export const pct = (part: number, total: number) => {
   return (part / total) * 100;
 };
 
-export const formatPct = (percentage: number) => {
+export const formatPct = (percentage: number, hideSymbol: boolean = false) => {
   const fractionDigits = percentage === 0 || percentage >= 100 ? 0 : 1;
-  return `${percentage.toFixed(fractionDigits)}%`;
+  return `${percentage.toFixed(fractionDigits)}${hideSymbol ? "" : "%"}`;
 };


### PR DESCRIPTION
This PR makes several tweaks to the compat matrix to improve understanding:

- Adds information on which Cloudflare column equates to which node(js)_compat version
- Replaces raw API numbers with percentages for missing, mismatch, and stub. (because the raw number only means something in the context of the total IMHO)
- Adds information in notes to help the user understand columns and definitions
- Adds a subtitle explaining the "/"ed numbers in each cell
- Adds disclaimer about data being generated via script
- Rename Supported -> Present, Unsupported -> Missing, Stub -> Mock

Note: I am a tad worried about all the percentage calculations making rendering slow on expand and/or initial page load. I can revert this change if that's an issue - or alternatively update the data to include these percentages so we have them pre-calculated.

![Screenshot 2024-08-29 at 10 00 53 AM](https://github.com/user-attachments/assets/dc220724-e71d-433b-a8f1-e126c701f7ad)

